### PR TITLE
Upgrade Elixir to 1.5.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM alpine:3.5
+FROM alpine:3.7
 
-ENV ELIXIR_VERSION "1.4.2"
-ENV ERLANG_VERSION "19.2"
-ENV ASDF_VERSION   "v0.2.1"
+ENV ELIXIR_VERSION "1.5.2"
+ENV ERLANG_VERSION "20.2"
+ENV ASDF_VERSION   "v0.4.1"
 
 RUN apk add --no-cache bash curl alpine-sdk perl openssl openssh-client openssl-dev ncurses ncurses-dev unixodbc unixodbc-dev python py-pip py-setuptools git ca-certificates nodejs && \
     export PATH="$HOME/.asdf/bin:$HOME/.asdf/shims:$PATH" && \


### PR DESCRIPTION
Upgrade Elixir and others.

- Elixir 1.5.2
- Erlang 20.2
- ASDF v0.4.1
- Alipine: 3.7