### PR TITLE
Upgrade to Elixir 1.6.6 and Erlang/OTP 21.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM alpine:3.7
 
-ENV ELIXIR_VERSION "1.6.5-otp-20"
-ENV ERLANG_VERSION "20.3"
-ENV ASDF_VERSION   "v0.4.1"
+ENV ELIXIR_VERSION "1.6.6-otp-21"
+ENV ERLANG_VERSION "21.0"
+ENV ASDF_VERSION   "v0.5.0"
 
-RUN apk add --no-cache autoconf bash curl alpine-sdk perl openssl openssh-client openssl-dev ncurses ncurses-dev unixodbc unixodbc-dev python py-pip py-setuptools git ca-certificates nodejs && \
+RUN apk add --no-cache autoconf bash curl alpine-sdk perl openssl openssh-client openssl-dev ncurses ncurses-dev unixodbc unixodbc-dev python py-pip py-setuptools git ca-certificates nodejs libxslt libxml2-utils && \
     export PATH="$HOME/.asdf/bin:$HOME/.asdf/shims:$PATH" && \
     echo "PATH=$HOME/.asdf/bin:$HOME/.asdf/shims:$PATH" >> /root/.profile && \
     git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch $ASDF_VERSION && \


### PR DESCRIPTION
Upgrades below.

- [Elixir v1.6.6 · elixir-lang/elixir](https://github.com/elixir-lang/elixir/releases/tag/v1.6.6)
- [Erlang OTP 21.0](http://www.erlang.org/news/123)
- [asdf 0.5.0](https://github.com/asdf-vm/asdf/blob/master/CHANGELOG.md#050)

and add `libxslt` amd `libxml2-utils` to compile Erlang.