### PR TITLE
[Amazon Linux] Upgrade to Elixir 1.6.6 and Erlang/OTP 21.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM amazonlinux:1
 
-ENV ELIXIR_VERSION "1.6.5-otp-20"
-ENV ERLANG_VERSION "20.3"
-ENV ASDF_VERSION   "v0.4.1"
+ENV ELIXIR_VERSION "1.6.6-otp-21"
+ENV ERLANG_VERSION "21.0"
+ENV ASDF_VERSION   "v0.5.0"
 ENV ASDF_DIR /opt/asdf
 ENV PATH "/opt/asdf/bin:/opt/asdf/shims:$PATH"
 
@@ -22,4 +22,3 @@ RUN yum groupinstall -y 'Development Tools' && \
     pip install --no-cache-dir python-dateutil && \
     git clone https://github.com/s3tools/s3cmd.git /opt/s3cmd && \
     ln -s /opt/s3cmd/s3cmd /usr/bin/s3cmd
-


### PR DESCRIPTION
Upgrades below.

- [Elixir v1.6.6 · elixir-lang/elixir](https://github.com/elixir-lang/elixir/releases/tag/v1.6.6)
- [Erlang OTP 21.0](http://www.erlang.org/news/123)
- [asdf 0.5.0](https://github.com/asdf-vm/asdf/blob/master/CHANGELOG.md#050)
