### PR TITLE
Upgrade Elixir 1.9.0 and Erlang OTP/22.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM amazonlinux:1
 
 ENV LANG en_US.UTF-8
 
-ENV ELIXIR_VERSION "1.8.1-otp-21"
-ENV ERLANG_VERSION "21.0"
+ENV ELIXIR_VERSION "1.9.0-otp-22"
+ENV ERLANG_VERSION "22.0"
 ENV ASDF_VERSION   "v0.5.1"
 ENV ASDF_DIR /opt/asdf
 ENV PATH "/opt/asdf/bin:/opt/asdf/shims:$PATH"


### PR DESCRIPTION
Upgrade Elixir 1.9.0 and Erlang OTP/22.0 🎉 

- [Elixir ChangeLog](https://github.com/elixir-lang/elixir/blob/v1.9/CHANGELOG.md)
- [Elixir v1.9 released](https://elixir-lang.org/blog/2019/06/24/elixir-v1-9-0-released/)
- [Erlang OTP 22.0 is released](http://www.erlang.org/news/132)
