### PR TITLE
Fix tag pattern

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,7 +3,7 @@ name: Docker
 on:
   push:
     tags:
-      - *
+      - '*'
 
 env:
   IMAGE_NAME: docker-elixir


### PR DESCRIPTION
Actions was not activated because the filter pattern was wrong 😇 


ref: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet

'*' | Matches all branch and tag names that don't contain a slash (/). The * character is a special character in YAML. When you start a pattern with *, you must use quotes.
-- | --


