### PR TITLE
Upgrade OTP version to 22.3.4.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM amazonlinux:1
 ENV LANG en_US.UTF-8
 
 ENV ELIXIR_VERSION "1.9.1-otp-22"
-ENV ERLANG_VERSION "22.0"
+ENV ERLANG_VERSION "22.3.4.11"
 ENV ASDF_VERSION   "v0.5.1"
 ENV ASDF_DIR /opt/asdf
 ENV PATH "/opt/asdf/bin:/opt/asdf/shims:$PATH"


### PR DESCRIPTION
Hi, folks! 

I'd like to update the OTP version to 22.3.4.11 because it is essential to compile Ecto 3.4.5. 